### PR TITLE
Added countdown options for next throw 

### DIFF
--- a/bounce.lua
+++ b/bounce.lua
@@ -45,8 +45,11 @@ local throw_speed_y = 50
 local velocity_x = 0
 --- current vertical velocity
 local velocity_y = 0
---- frames to wait before throwing again
-local wait_frames = 1
+--- current maximum and minimal frames to wait before throwing again
+local max_frames = 10
+local min_frames = 60
+--- frames to wait before throwing again. This variable is randomized or set using the max and min timer variables above. 
+local wait_frames = 0
 -- physics config
 local gravity = 0.98
 local air_drag = 0.99
@@ -100,6 +103,9 @@ function script_properties()
    obs.obs_properties_add_int_slider(props, 'speed', 'DVD Bounce Speed:', 1, 30, 1)
    obs.obs_properties_add_int_slider(props, 'throw_speed_x', 'Max Throw Speed (X):', 1, 200, 1)
    obs.obs_properties_add_int_slider(props, 'throw_speed_y', 'Max Throw Speed (Y):', 1, 100, 1)
+   obs.obs_properties_add_int(props, 'min_timer_op', 'Shortest time until next throw (seconds)', 1, 3600, 1)
+   obs.obs_properties_add_int(props, 'max_timer_op', 'Longest amount of time until next throw(seconds)', 1, 3600, 1 )
+
    obs.obs_properties_add_bool(props, 'start_on_scene_change', 'Start on scene change')
    obs.obs_properties_add_button(props, 'button', 'Toggle', toggle)
    return props
@@ -110,6 +116,8 @@ function script_defaults(settings)
    obs.obs_data_set_default_int(settings, 'speed', speed)
    obs.obs_data_set_default_int(settings, 'throw_speed_x', throw_speed_x)
    obs.obs_data_set_default_int(settings, 'throw_speed_y', throw_speed_y)
+   obs.obs_data_set_default_int(settings, 'min_timer_op', min_timer_op)
+   obs.obs_data_set_default_int(settings, 'max_timer_op', max_timer_op)
 end
 
 function script_update(settings)
@@ -120,6 +128,8 @@ function script_update(settings)
    speed = obs.obs_data_get_int(settings, 'speed')
    throw_speed_x = obs.obs_data_get_int(settings, 'throw_speed_x')
    throw_speed_y = obs.obs_data_get_int(settings, 'throw_speed_y')
+   min_timer_op = obs.obs_data_get_int(settings, 'min_timer_op')
+   max_timer_op = obs.obs_data_get_int(settings, 'max_timer_op')
    start_on_scene_change = obs.obs_data_get_bool(settings, 'start_on_scene_change')
    -- don't lose original_pos when config is changed
    if old_source_name ~= source_name or old_bounce_type ~= bounce_type then
@@ -254,7 +264,7 @@ function throw_scene_item(scene_item)
 
    if velocity_y == 0 and velocity_x < 0.75 then
       velocity_x = 0
-      wait_frames = 60 * 1
+      wait_frames = math.random(min_timer_op, max_timer_op) * 60 
       return
    end
 

--- a/bounce.lua
+++ b/bounce.lua
@@ -13,6 +13,7 @@ local bit = require('bit')
 local bounce_type = 'dvd_bounce'
 --- name of the scene item to be moved
 local source_name = ''
+
 --- if true bouncing will auto start on scene change
 local start_on_scene_change = false
 --- the hotkey assigned to toggle_bounce in OBS's hotkey config
@@ -103,8 +104,8 @@ function script_properties()
    obs.obs_properties_add_int_slider(props, 'speed', 'DVD Bounce Speed:', 1, 30, 1)
    obs.obs_properties_add_int_slider(props, 'throw_speed_x', 'Max Throw Speed (X):', 1, 200, 1)
    obs.obs_properties_add_int_slider(props, 'throw_speed_y', 'Max Throw Speed (Y):', 1, 100, 1)
-   obs.obs_properties_add_int(props, 'min_timer_op', 'Shortest time until next throw (seconds)', 1, 3600, 1)
-   obs.obs_properties_add_int(props, 'max_timer_op', 'Longest amount of time until next throw(seconds)', 1, 3600, 1 )
+   obs.obs_properties_add_int(props, 'min_frames', 'Shortest time until next throw (seconds)', 1, 3600, 1)
+   obs.obs_properties_add_int(props, 'max_frames', 'Longest amount of time until next throw(seconds)', 1, 3600, 1 )
 
    obs.obs_properties_add_bool(props, 'start_on_scene_change', 'Start on scene change')
    obs.obs_properties_add_button(props, 'button', 'Toggle', toggle)
@@ -116,8 +117,8 @@ function script_defaults(settings)
    obs.obs_data_set_default_int(settings, 'speed', speed)
    obs.obs_data_set_default_int(settings, 'throw_speed_x', throw_speed_x)
    obs.obs_data_set_default_int(settings, 'throw_speed_y', throw_speed_y)
-   obs.obs_data_set_default_int(settings, 'min_timer_op', min_timer_op)
-   obs.obs_data_set_default_int(settings, 'max_timer_op', max_timer_op)
+   obs.obs_data_set_default_int(settings, 'min_frames', min_frames)
+   obs.obs_data_set_default_int(settings, 'max_frames', max_frames)
 end
 
 function script_update(settings)
@@ -128,8 +129,8 @@ function script_update(settings)
    speed = obs.obs_data_get_int(settings, 'speed')
    throw_speed_x = obs.obs_data_get_int(settings, 'throw_speed_x')
    throw_speed_y = obs.obs_data_get_int(settings, 'throw_speed_y')
-   min_timer_op = obs.obs_data_get_int(settings, 'min_timer_op')
-   max_timer_op = obs.obs_data_get_int(settings, 'max_timer_op')
+   min_frames= obs.obs_data_get_int(settings, 'min_frames')
+   max_frames = obs.obs_data_get_int(settings, 'max_frames')
    start_on_scene_change = obs.obs_data_get_bool(settings, 'start_on_scene_change')
    -- don't lose original_pos when config is changed
    if old_source_name ~= source_name or old_bounce_type ~= bounce_type then
@@ -264,7 +265,7 @@ function throw_scene_item(scene_item)
 
    if velocity_y == 0 and velocity_x < 0.75 then
       velocity_x = 0
-      wait_frames = math.random(min_timer_op, max_timer_op) * 60 
+      wait_frames = math.random(min_frames, max_frames) * 60 
       return
    end
 

--- a/bounce.lua
+++ b/bounce.lua
@@ -52,8 +52,8 @@ local min_frames = 60
 --- frames to wait before throwing again. This variable is randomized or set using the max and min timer variables above. 
 local wait_frames = 0
 -- physics config
-local gravity = 0.98
-local air_drag = 0.99
+local gravity = 100           -- Gravity used to be 0.98. OBS didn't like using float so to still having the option to be accurate I instead increased the gravity by 100 times here. 
+local air_drag = 0.99         -- Later in the code it gets divided by 100 again. Making sure the ratio stays the same while still giving people the option to change strength with accuracy
 local ground_friction = 0.95
 local elasticity = 0.8
 
@@ -106,7 +106,7 @@ function script_properties()
    obs.obs_properties_add_int_slider(props, 'throw_speed_y', 'Max Throw Speed (Y):', 1, 100, 1)
    obs.obs_properties_add_int(props, 'min_frames', 'Shortest time until next throw (seconds)', 1, 3600, 1)
    obs.obs_properties_add_int(props, 'max_frames', 'Longest amount of time until next throw(seconds)', 1, 3600, 1 )
-
+   obs.obs_properties_add_int_slider(props, 'gravity', 'Strength of gravity (%) (Default is 100%)', 1, 300, 1)
    obs.obs_properties_add_bool(props, 'start_on_scene_change', 'Start on scene change')
    obs.obs_properties_add_button(props, 'button', 'Toggle', toggle)
    return props
@@ -119,6 +119,7 @@ function script_defaults(settings)
    obs.obs_data_set_default_int(settings, 'throw_speed_y', throw_speed_y)
    obs.obs_data_set_default_int(settings, 'min_frames', min_frames)
    obs.obs_data_set_default_int(settings, 'max_frames', max_frames)
+   obs.obs_data_set_default_int(settings, 'gravity', gravity)
 end
 
 function script_update(settings)
@@ -131,6 +132,7 @@ function script_update(settings)
    throw_speed_y = obs.obs_data_get_int(settings, 'throw_speed_y')
    min_frames= obs.obs_data_get_int(settings, 'min_frames')
    max_frames = obs.obs_data_get_int(settings, 'max_frames')
+   gravity = obs.obs_data_get_int(settings, 'gravity') / 100
    start_on_scene_change = obs.obs_data_get_bool(settings, 'start_on_scene_change')
    -- don't lose original_pos when config is changed
    if old_source_name ~= source_name or old_bounce_type ~= bounce_type then


### PR DESCRIPTION
I really liked this script but I found it a bit annoying how I couldn't change the timer until next throw, and was forced to go into the file itself and edit it. So I took the time and added some stuff and there is now two new options that people can use. I've tested it with several different combinations of settings and it all seems to work. 

- "Shortest time until next throw (seconds)" 
-"Longest amount of time until next throw(seconds)" 
Range is 1 to 3600 seconds. Meaning that the longest time until next throw is an hour. Setting the two values will obviously not randomize the throws anymore and will instead just countdown the time set and throw the little cute cat or whatever the source is. 

NOTE: I have never edited a OBS script, nor Lua before so if any of the code I added is not usable for some reason that I'm not aware of, please tell me because I would love to learn more about it. I didn't even know Lua existed before today.  Same goes for github, I'm honestly so lost in this process so please do tell me If I've misunderstood anything